### PR TITLE
Fix description getting wrongly changed upon publish

### DIFF
--- a/Packages/com.bocud.vrbuildhelper/BuildHelper/Runtime/BuildHelperData.cs
+++ b/Packages/com.bocud.vrbuildhelper/BuildHelper/Runtime/BuildHelperData.cs
@@ -207,7 +207,7 @@ namespace BocuD.BuildHelper
             ApiWorld world = await FetchApiWorldAsync(blueprintID);
             
             target.editedName = world.name;
-            target.editedDescription = world.name;
+            target.editedDescription = world.description;
             target.editedCap = world.capacity;
             target.editedTags = world.publicTags.ToList();
 


### PR DESCRIPTION
This fixes the description getting wrongly set to the world's name upon successful publish.