### PR TITLE
Initialize branches to an empty array

### DIFF
--- a/Packages/com.bocud.vrbuildhelper/BuildHelper/Runtime/BuildHelperData.cs
+++ b/Packages/com.bocud.vrbuildhelper/BuildHelper/Runtime/BuildHelperData.cs
@@ -266,7 +266,7 @@ namespace BocuD.BuildHelper
     {
         public int currentBranch;
 
-        public Branch[] branches;
+        public Branch[] branches = new Branch[0];
         
         public Branch GetBranchByID(string id)
         {


### PR DESCRIPTION
This fixes an error when opening build helper in a scene that contains no build helper data, and lets it initialize properly